### PR TITLE
Changed to an Overlappable instance

### DIFF
--- a/src/Opaleye/Record.hs
+++ b/src/Opaleye/Record.hs
@@ -385,7 +385,7 @@ printSql = putStrLn . maybe "Empty query" id . showSqlForPostgres
 instance {-# OVERLAPPABLE #-} Default Constant a a where
   def = Constant id
   
-instance {-# OVERLAPPABLE #-} Default Constant a (Maybe a) where
+instance Default Constant a (Maybe a) where
   def = Constant Just
 
 instance (KnownSymbol tyName) => IsSqlType (PGCustom ty (EnumRep ('PGTypeName tyName) enums)) where

--- a/src/Opaleye/Record.hs
+++ b/src/Opaleye/Record.hs
@@ -382,10 +382,10 @@ printSql :: Default Unpackspec a a => Query a -> IO ()
 printSql = putStrLn . maybe "Empty query" id . showSqlForPostgres
 
 
-instance Default Constant a a where
+instance {-# OVERLAPPABLE #-} Default Constant a a where
   def = Constant id
   
-instance Default Constant a (Maybe a) where
+instance {-# OVERLAPPABLE #-} Default Constant a (Maybe a) where
   def = Constant Just
 
 instance (KnownSymbol tyName) => IsSqlType (PGCustom ty (EnumRep ('PGTypeName tyName) enums)) where


### PR DESCRIPTION
When trying to use constant to pass from a projected instance in Haskell to a projected instance in Opaleye, there was an overlapping instances problem with Default Constant () () as (Default p a b => Default p (Const a c) (Const b c')) is defined in Data.Profunctor.Product.Default and Default Constant a a is defined in Opaleye.Record.

This just adds an overlappable flag.
